### PR TITLE
adding 'distributionManagement' section to pom files

### DIFF
--- a/jdeeco-core/pom.xml
+++ b/jdeeco-core/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>com.github.stefanbirkner</groupId>
 			<artifactId>system-rules</artifactId>
-			<version>1.4.0</version>
+			<version>1.6.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -87,4 +87,11 @@
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>
+	<distributionManagement>
+ 		<repository>
+			<id>d3s</id>
+			<name>D3S maven repository</name>
+			<url>https://gitlab.d3s.mff.cuni.cz:8443/nexus/content/repositories/releases</url>
+		</repository>
+	</distributionManagement>
 </project>

--- a/jdeeco-parent/pom.xml
+++ b/jdeeco-parent/pom.xml
@@ -60,10 +60,11 @@
 			</plugins>
 		</pluginManagement>
 	</build>
-	<repositories>
-		<repository>
-			<id>sonatype.releases</id>
-			<url>http://oss.sonatype.org/content/repositories/releases/</url>
+	<distributionManagement>
+ 		<repository>
+			<id>d3s</id>
+			<name>D3S maven repository</name>
+			<url>https://gitlab.d3s.mff.cuni.cz:8443/nexus/content/repositories/releases</url>
 		</repository>
-	</repositories>
+	</distributionManagement>
 </project>


### PR DESCRIPTION
Deployment a project to the D3S maven repo is now possible via:
1. setting up the .m2/settings.xml file with the credentials (see email from Tomas from June 15th)
2. navigating to the directory with the pom file of the project we want to deploy (root of Eclipse project)
3. issuing "mvn deploy"
