### PR TITLE
Ensemble logging now called at proper places

### DIFF
--- a/jdeeco-core/src/cz/cuni/mff/d3s/deeco/task/EnsembleLogger.java
+++ b/jdeeco-core/src/cz/cuni/mff/d3s/deeco/task/EnsembleLogger.java
@@ -238,16 +238,25 @@ public class EnsembleLogger {
 	 * @param shadowKnowledgeManager Knowledge of the other component
 	 * @param timeProvider Used to get the current time
 	 * @param membership The current value of the membership condition
+	 * @param reversedRoles If true, the agent whose knowledge is in shadowKnowledgeManager 
+	 * is consider as the coordinator. If false, it is considered as a member. 
 	 */
 	public void logEvent(EnsembleController ensembleController, ReadOnlyKnowledgeManager shadowKnowledgeManager, 
-			CurrentTimeProvider timeProvider, boolean membership){
+			CurrentTimeProvider timeProvider, boolean membership, boolean reversedRoles){
 		if ((out == null) || (ensembleController == null) || (shadowKnowledgeManager == null) || (timeProvider == null)){
 			return;
 		}		
 		long timeSeconds = timeProvider.getCurrentMilliseconds() / 1000L;
 		String ensembleName = ensembleController.getEnsembleDefinition().getName();
-		String coordinatorID = ensembleController.getComponentInstance().getKnowledgeManager().getId();
-		String memberID = shadowKnowledgeManager.getId();
+		String coordinatorID;
+		String memberID;
+		if (reversedRoles){
+			memberID = ensembleController.getComponentInstance().getKnowledgeManager().getId();
+			coordinatorID = shadowKnowledgeManager.getId();
+		} else {
+			coordinatorID = ensembleController.getComponentInstance().getKnowledgeManager().getId();
+			memberID = shadowKnowledgeManager.getId();
+		}
 		EnsembleLogger.MembershipRecord mr = new MembershipRecord(ensembleName, coordinatorID, memberID);
 		boolean oldMembership = membershipRecords.get(mr) == null ? false : membershipRecords.get(mr);
 		if (oldMembership != membership){

--- a/jdeeco-core/src/cz/cuni/mff/d3s/deeco/task/EnsembleTask.java
+++ b/jdeeco-core/src/cz/cuni/mff/d3s/deeco/task/EnsembleTask.java
@@ -672,14 +672,17 @@ public class EnsembleTask extends Task {
 			coordinatorExchangePerformed = performExchange(PathRoot.COORDINATOR, shadowKnowledgeManager);
 			membership = true;
 		}
-		EnsembleLogger.getInstance().logEvent(ensembleController, shadowKnowledgeManager, scheduler, membership);
+		EnsembleLogger.getInstance().logEvent(ensembleController, shadowKnowledgeManager, scheduler, membership, false);
 		
 		// Do the same with the roles exchanged
+		membership = false;
 		if (checkMembership(PathRoot.MEMBER, shadowKnowledgeManager) && securityChecker.checkSecurity(PathRoot.MEMBER, shadowKnowledgeManager)) {
 			architectureObserver.ensembleFormed(ensembleController.getEnsembleDefinition(), ensembleController.getComponentInstance(),
 					shadowKnowledgeManager.getId(), ensembleController.getComponentInstance().getKnowledgeManager().getId());
-			memberExchangePerformed = performExchange(PathRoot.MEMBER, shadowKnowledgeManager);			
+			memberExchangePerformed = performExchange(PathRoot.MEMBER, shadowKnowledgeManager);
+			membership = true;
 		}
+		EnsembleLogger.getInstance().logEvent(ensembleController, shadowKnowledgeManager, scheduler, membership, true);
 		
 		if (coordinatorExchangePerformed || memberExchangePerformed) {
 			invokeRatingsProcess(shadowKnowledgeManager.getId());


### PR DESCRIPTION
Bug fix: the ensemble logging is now called at both places in evaluateMembershipAndPerformExchange(), i.e. also with the roles exchanged.